### PR TITLE
Do github actions on arm systems

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ubuntu-latest"]
+        platform: ["ubuntu-24.04-arm"]
         python-version: ["3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,11 +50,6 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: all
-
     - uses: pypa/cibuildwheel@v2.22.0
       env:
         CIBW_ARCHS_LINUX: ${{ matrix.arch_linux }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build_sdist:
     name: Build SDist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v4
       with:
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-24.04-arm"]
         arch_linux: ["aarch64"]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This is faster and avoids some segfaults that the elves have sprinkled in cibuildwheel lately (I read https://github.com/pypa/cibuildwheel/issues/2257 but didn't follow the rabbit hole all the way to the bottom)