### PR TITLE
Share program space

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,8 @@ uint8_t reuse_or_add_program(PIO pio, int8_t offset, const program &instructions
     i.refcnt++;
     i.offset = offset;
 
+    pi = &i;
+
     return offset;
 }
 
@@ -162,7 +164,7 @@ class StateMachine {
     int sm{-1};
     int offset{-1};
     double frequency;
-    program_info *pi;
+    program_info *pi = nullptr;
 
     void check_for_deinit() {
         if(PIO_IS_ERR(pio)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,8 +62,9 @@ PIO pio_open_check() {
 
     PIO pio = pio_open(0);
     if(PIO_IS_ERR(pio)) {
+        int err = PIO_ERR_VAL(pio);
         throw std::runtime_error(
-            py::str("Failed to open PIO device (error {})").attr("format")(PIO_ERR_VAL(pio)).cast<std::string>());
+            py::str("Failed to open PIO device (error {})").attr("format")(strerror(err)).cast<std::string>());
     }
     return pio;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -245,8 +245,8 @@ public:
                 throw py::value_error("sideset_pin_count out of range");
             }
 
-            PIO_PINMASK_MERGE(pindirs, PIO_PINMASK_CONSECUTIVE_PINS(sideset_pin_count, first_sideset_pin_number));
-            PIO_PINMASK_MERGE(pins_we_use, PIO_PINMASK_CONSECUTIVE_PINS(sideset_pin_count, first_sideset_pin_number));
+            PIO_PINMASK_MERGE(pindirs, PIO_PINMASK_CONSECUTIVE_PINS(first_sideset_pin_number, sideset_pin_count));
+            PIO_PINMASK_MERGE(pins_we_use, PIO_PINMASK_CONSECUTIVE_PINS(first_sideset_pin_number, sideset_pin_count));
 
             for(int i=0; i<sideset_pin_count; i++) {
                 pio_gpio_init(pio, first_sideset_pin_number + i);
@@ -266,7 +266,7 @@ public:
             sm_config_set_in_pins(&c, first_in_pin_number);
             PIO_PINMASK_MERGE(pin_pull_up, PIO_PINMASK_FROM_VALUE(pull_in_pin_up << first_in_pin_number));
             PIO_PINMASK_MERGE(pin_pull_down, PIO_PINMASK_FROM_VALUE(pull_in_pin_down << first_in_pin_number));
-            PIO_PINMASK_MERGE(pins_we_use, PIO_PINMASK_CONSECUTIVE_PINS(in_pin_count, first_in_pin_number));
+            PIO_PINMASK_MERGE(pins_we_use, PIO_PINMASK_CONSECUTIVE_PINS(first_in_pin_number, in_pin_count));
         }
 
         pio_sm_set_pindirs_with_mask(pio, sm, PIO_PINMASK_VALUE(pindirs), PIO_PINMASK_VALUE(pins_we_use));


### PR DESCRIPTION
Testing performed: I can now create 3 encoder objects (and call neopixel_write) at the same time within the same Python program and don't get a Python exception.

Sadly, while working on this I made a wiring mistake and toasted my fancy CNC encoder wheel so I can't 100% verify the code is working now. I'll do more testing when I get some new mechanical encoder wheels in hand, likely tomorrow.